### PR TITLE
Use mirrorlist.c.o for the repository

### DIFF
--- a/CentOS-Gluster-5.repo
+++ b/CentOS-Gluster-5.repo
@@ -5,7 +5,8 @@
 
 [centos-gluster5]
 name=CentOS-$releasever - Gluster 5
-baseurl=http://mirror.centos.org/$contentdir/$releasever/storage/$basearch/gluster-5/
+mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=$releasever&repo=storage-gluster-5
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/storage/$basearch/gluster-5/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Storage


### PR DESCRIPTION
mirrorlist.centos.org knows about SIG and AltArch content now, so traffic can be routed to potentially faster and closer external mirrors instead of mirror.centos.org